### PR TITLE
switch youbara script load from http url to relative url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var integration = require('@segment/analytics.js-integration');
 
 var Youbora = module.exports = integration('Youbora')
   .option('accountCode', '')
-  .tag('<script src="//smartplugin.youbora.com/v5/javascript/libs/5.4.6/youboralib.js">');
+  .tag('<script src="https//smartplugin.youbora.com/v5/javascript/libs/5.4.6/youboralib.js">');
 
 /**
  * Initialize.


### PR DESCRIPTION
Switched script source to use relative URL. This will result in HTTP sites not loading in the youbora script over HTTP.