### PR TITLE
update youbora scripts to load over https

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,13 +13,13 @@ var reject = require('reject');
 
 var Youbora = module.exports = integration('Youbora')
   .option('accountCode', '')
-  .tag('youbora-dashjs', '<script src="http://smartplugin.youbora.com/v6/js/adapters/dashjs/6.1.0/sp.min.js">')
-  .tag('youbora-html5', '<script src="http://smartplugin.youbora.com/v6/js/adapters/html5/6.0.0/sp.min.js">')
-  .tag('youbora-jwplayer', '<script src="http://smartplugin.youbora.com/v6/js/adapters/jwplayer7/6.1.2/sp.min.js">')
-  .tag('youbora-theoplayer', '<script src="http://smartplugin.youbora.com/v6/js/adapters/theoplayer2/6.1.1/sp.min.js">')
-  .tag('youbora-theplatform', '<script src="http://smartplugin.youbora.com/v6/js/adapters/theplatform/6.1.0/sp.min.js">')
-  .tag('youbora-videojs', '<script src="http://smartplugin.youbora.com/v6/js/adapters/videojs5/6.1.7/sp.min.js">')
-  .tag('youbora-main', '<script src="http://smartplugin.youbora.com/v6/js/lib/6.0.0/youboralib.min.js">');
+  .tag('youbora-dashjs', '<script src="https://smartplugin.youbora.com/v6/js/adapters/dashjs/6.1.0/sp.min.js">')
+  .tag('youbora-html5', '<script src="https://smartplugin.youbora.com/v6/js/adapters/html5/6.0.0/sp.min.js">')
+  .tag('youbora-jwplayer', '<script src="https://smartplugin.youbora.com/v6/js/adapters/jwplayer7/6.1.2/sp.min.js">')
+  .tag('youbora-theoplayer', '<script src="https://smartplugin.youbora.com/v6/js/adapters/theoplayer2/6.1.1/sp.min.js">')
+  .tag('youbora-theplatform', '<script src="https://smartplugin.youbora.com/v6/js/adapters/theplatform/6.1.0/sp.min.js">')
+  .tag('youbora-videojs', '<script src="https://smartplugin.youbora.com/v6/js/adapters/videojs5/6.1.7/sp.min.js">')
+  .tag('youbora-main', '<script src="https://smartplugin.youbora.com/v6/js/lib/6.0.0/youboralib.min.js">');
 
 Youbora.prototype.loaded = function() {
   return !!window.youbora;


### PR DESCRIPTION
This PR updated the Youbora scripts to load via HTTPS instead of HTTP. This is a security issue for sites using HTTPS as they shouldn't be loading insecure resources. This was reported by Fox today, and its a repeat of the earlier issue they had.